### PR TITLE
Make it possible to run with "flask run" (dev mode) without uwsgi.

### DIFF
--- a/app/app.py
+++ b/app/app.py
@@ -6,12 +6,18 @@ import redis
 
 HTTP_STATUS_OK = 200
 HTTP_STATUS_SERVER_ERROR = 500
-app = Flask(__name__)
+app = Flask(__name__, static_url_path='', static_folder='./static')
+
 slave_replicas = int(os.getenv("REDIS_SLAVE_REPLICAS", 1))
 write_timeout = int(os.getenv("REDIS_WRITE_TIMEOUT", 10)) * 1000
 
 redis_master = redis.Redis(host="redis-master", port=6379, db=0)
 redis_slave = redis.Redis(host="redis-slave", port=6379, db=0)
+
+
+@app.route("/")
+def index():
+    return app.send_static_file("index.html")
 
 
 @app.route("/api/data/<key>")

--- a/app/requirements.txt
+++ b/app/requirements.txt
@@ -1,3 +1,3 @@
 Flask==1.0
 redis==2.10.6
-uWSGI==2.0.15
+uWSGI==2.0.20


### PR DESCRIPTION
This allows us to workaround an issue spotted only with uwsgi + RHEL9

In the kubernetes yaml the command for the container can be overruled to use flask run if needed.

Also updated uWSGI to latest version, but did not solve the issue.